### PR TITLE
chore(dependencies): Update package name formatting in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
-  "name": "LazyStack",
+  "name": "lazystack",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "lazystack",
+      "version": "0.0.1",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",


### PR DESCRIPTION
- Changed `name` field from `LazyStack` to `lazystack` for consistency
- Ensured alignment with `package.json` metadata
- Maintained dependency structure without altering versions