### PR TITLE
fix(data): Update Together AI icon path to align with AI category

### DIFF
--- a/src/constants/ai-tools.data.ts
+++ b/src/constants/ai-tools.data.ts
@@ -521,7 +521,7 @@ export const aiTools = [
     title: "Together",
     description:
       "200+ generative AI models. Build with open-source and specialized multimodal models for chat, images, code, and more.",
-    icon: "/assets/development/together-icon.png",
+    icon: "/assets/ai/together-icon.png",
     category: "Development",
     benefits: [
       "200+ models: Choose from open-source and specialized multimodal models for chat, images, code, and more",


### PR DESCRIPTION
- Changed icon path from /assets/development to /assets/ai
- Ensures consistency with category-based asset organization