### PR TITLE
refactor(dialog): use semantic header and footer elements

### DIFF
--- a/src/components/ui/custom-dialog.tsx
+++ b/src/components/ui/custom-dialog.tsx
@@ -55,8 +55,8 @@ DialogContentWithoutCloseButton.displayName = "DialogContentWithoutCloseButton";
 export const DialogHeader = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
+}: React.HTMLAttributes<HTMLElement>) => (
+  <header
     className={cn(
       "flex flex-col space-y-1.5 text-center sm:text-left",
       className,
@@ -70,7 +70,7 @@ export const DialogFooter = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
+  <footer
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
       className,


### PR DESCRIPTION
- change DialogHeader to use <header> for better semantics

- change DialogFooter to use <footer> for improved accessibility

- update DialogHeader type from HTMLDivElement to HTMLElement

- enhance accessibility and document structure for assistive tech