### PR TITLE
refactor(types): centralize component prop types into dedicated type files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.autoClosingTags": false
+}

--- a/src/components/Cards/BenefitsList.tsx
+++ b/src/components/Cards/BenefitsList.tsx
@@ -1,9 +1,4 @@
-import React from "react";
-
-interface BenefitsListProps {
-  benefits: string[];
-  theme: string | undefined;
-}
+import { BenefitsListProps } from "@/types/card-component-types";
 
 /**
  * Displays a list of benefit tags for a tool

--- a/src/components/Cards/CardFooter.tsx
+++ b/src/components/Cards/CardFooter.tsx
@@ -1,12 +1,6 @@
-import React from "react";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
-
-interface CardFooterProps {
-  highlight: string;
-  theme: string | undefined;
-  onViewDetails: () => void;
-}
+import { CardFooterProps } from "@/types/card-component-types";
 
 /**
  * Footer component for Tool Cards with highlight badge and action button

--- a/src/components/Cards/CategoryBadge.tsx
+++ b/src/components/Cards/CategoryBadge.tsx
@@ -1,9 +1,4 @@
-import React from "react";
-
-interface CategoryBadgeProps {
-  category: string;
-  theme: string | undefined;
-}
+import { CategoryBadgeProps } from "@/types/card-component-types";
 
 /**
  * Displays the category badge for a tool

--- a/src/components/Cards/ToolIcon.tsx
+++ b/src/components/Cards/ToolIcon.tsx
@@ -1,14 +1,5 @@
-import React from "react";
 import Image from "next/image";
-import { LucideIcon } from "lucide-react";
-
-interface ToolIconProps {
-  Icon?: LucideIcon;
-  imageIcon?: string;
-  title: string;
-  theme: string | undefined;
-  iconRef: React.RefObject<HTMLDivElement>;
-}
+import { ToolIconProps } from "@/types/card-component-types";
 
 /**
  * Displays either an image icon or Lucide icon for a tool

--- a/src/components/Categories/CategoryHeader.tsx
+++ b/src/components/Categories/CategoryHeader.tsx
@@ -1,10 +1,5 @@
-import React from "react";
 import { useTheme } from "next-themes";
-
-interface CategoryHeaderProps {
-  title: string;
-  description: string;
-}
+import { CategoryHeaderProps } from "@/types/category-component-types";
 
 /**
  * Section header for tool categories with title and description

--- a/src/components/Categories/Pagination.tsx
+++ b/src/components/Categories/Pagination.tsx
@@ -1,13 +1,7 @@
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useEffect, useState } from "react";
-
-interface PaginationProps {
-  currentPage: number;
-  totalPages: number;
-  onPageChange: (page: number) => void;
-  className?: string;
-}
+import { PaginationProps } from "@/types/category-component-types";
 
 export function Pagination({
   currentPage,

--- a/src/components/Categories/ToolCategories.tsx
+++ b/src/components/Categories/ToolCategories.tsx
@@ -4,7 +4,6 @@ import { useTheme } from "next-themes";
 import { useState } from "react";
 import { ToolCategoriesProps } from "@/types/tool-types";
 import { CategoryHeader } from "./CategoryHeader";
-import { Tool } from "@/types/tool-types";
 import ToolCard from "../Cards/ToolCard";
 import { Pagination } from "./Pagination";
 import { useCategoryTools } from "@/hooks/useCategoryTools";

--- a/src/components/Categories/ToolGrid.tsx
+++ b/src/components/Categories/ToolGrid.tsx
@@ -1,11 +1,5 @@
-import React from "react";
 import ToolCard from "../Cards/ToolCard";
-import { Tool } from "@/types/tool-types";
-
-interface ToolGridProps {
-  tools: Tool[];
-  initialToolsLoaded: boolean;
-}
+import { ToolGridProps } from "@/types/category-component-types";
 
 /**
  * Grid layout component for displaying tool cards

--- a/src/components/Footer/BackToTopButton.tsx
+++ b/src/components/Footer/BackToTopButton.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import { ChevronUp } from "lucide-react";
-
-interface BackToTopButtonProps {
-  showButton: boolean;
-  isDark: boolean;
-  onClick: () => void;
-}
+import { BackToTopButtonProps } from "@/types/footer-component-types";
 
 /**
  * A button that appears when scrolling down to let users quickly go back to the top

--- a/src/components/Footer/FooterBackground.tsx
+++ b/src/components/Footer/FooterBackground.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-
-interface FooterBackgroundProps {
-  isDark: boolean;
-}
+import { FooterBackgroundProps } from "@/types/footer-component-types";
 
 /**
  * Background visual effects for the footer

--- a/src/components/Footer/FooterBottom.tsx
+++ b/src/components/Footer/FooterBottom.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { Heart } from "lucide-react";
-
-interface FooterBottomProps {
-  isDark: boolean;
-  currentYear: number;
-}
+import { FooterBottomProps } from "@/types/footer-component-types";
 
 /**
  * Bottom section of the footer with copyright and credits

--- a/src/components/Footer/FooterBrand.tsx
+++ b/src/components/Footer/FooterBrand.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-
-interface FooterBrandProps {
-  isDark: boolean;
-}
+import { FooterBrandProps } from "@/types/footer-component-types";
 
 /**
  * The brand section of the footer with logo and description

--- a/src/components/Footer/FooterContact.tsx
+++ b/src/components/Footer/FooterContact.tsx
@@ -1,14 +1,9 @@
 import React from "react";
 import { Github, ExternalLink } from "lucide-react";
-
-interface FooterContactProps {
-  isDark: boolean;
-}
-
-interface ContactLink {
-  href: string;
-  username: string;
-}
+import {
+  FooterContactProps,
+  ContactLink,
+} from "@/types/footer-component-types";
 
 /**
  * Contact section in the footer with GitHub links

--- a/src/components/Footer/FooterDivider.tsx
+++ b/src/components/Footer/FooterDivider.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-
-interface FooterDividerProps {
-  isDark: boolean;
-}
+import { FooterDividerProps } from "@/types/footer-component-types";
 
 /**
  * Animated divider for separating footer sections

--- a/src/components/Footer/FooterNavigation.tsx
+++ b/src/components/Footer/FooterNavigation.tsx
@@ -1,14 +1,9 @@
 import React from "react";
 import Link from "next/link";
-
-interface FooterNavigationProps {
-  isDark: boolean;
-}
-
-interface NavigationLink {
-  href: string;
-  label: string;
-}
+import {
+  FooterNavigationProps,
+  NavigationLink,
+} from "@/types/footer-component-types";
 
 /**
  * Navigation links section in the footer

--- a/src/components/Jumbotron/Decorations.tsx
+++ b/src/components/Jumbotron/Decorations.tsx
@@ -1,9 +1,5 @@
-import React, { RefObject } from "react";
-
-interface DecorationsProps {
-  isDark: boolean;
-  decorationsRef: RefObject<HTMLDivElement>;
-}
+import React from "react";
+import { DecorationsProps } from "@/types/jumbotron-component-types";
 
 /**
  * Decorative elements for the jumbotron section

--- a/src/components/Jumbotron/FeatureCard.tsx
+++ b/src/components/Jumbotron/FeatureCard.tsx
@@ -6,12 +6,7 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import { FeatureItem } from "../../types/jumbotron-types";
-
-interface FeatureCardProps {
-  feature: FeatureItem;
-  isDark: boolean;
-}
+import { FeatureCardProps } from "@/types/jumbotron-component-types";
 
 /**
  * A card component for displaying feature information

--- a/src/components/Jumbotron/JumbotronBackground.tsx
+++ b/src/components/Jumbotron/JumbotronBackground.tsx
@@ -1,12 +1,5 @@
 import React from "react";
-import { MousePosition } from "../../types/jumbotron-types";
-
-interface JumbotronBackgroundProps {
-  isDark: boolean;
-  isMounted: boolean;
-  isMobileOrTablet: boolean;
-  mousePosition: MousePosition;
-}
+import { JumbotronBackgroundProps } from "@/types/jumbotron-component-types";
 
 /**
  * Component for displaying all the background visual elements of the jumbotron

--- a/src/components/Jumbotron/TerminalDisplay.tsx
+++ b/src/components/Jumbotron/TerminalDisplay.tsx
@@ -1,11 +1,5 @@
-import React, { RefObject } from "react";
-
-interface TerminalDisplayProps {
-  isDark: boolean;
-  typedText: string;
-  isTyping: boolean;
-  dashboardCodeRef: RefObject<HTMLDivElement>;
-}
+import React from "react";
+import { TerminalDisplayProps } from "@/types/jumbotron-component-types";
 
 /**
  * Terminal display component with animated typing effect

--- a/src/components/Loading/Terminal.tsx
+++ b/src/components/Loading/Terminal.tsx
@@ -1,15 +1,7 @@
 import React from "react";
-import { TerminalStyle } from "../../types/terminal-types";
+import { TerminalProps } from "@/types/loading-component-types";
 import { TerminalHeader } from "./TerminalHeader";
 import { TerminalContent } from "./TerminalContent";
-
-interface TerminalProps {
-  style: TerminalStyle;
-  text: string;
-  lineText: string;
-  animationComplete: boolean;
-  title?: string;
-}
 
 /**
  * Terminal window component combining header and content

--- a/src/components/Loading/TerminalContent.tsx
+++ b/src/components/Loading/TerminalContent.tsx
@@ -1,12 +1,5 @@
 import React from "react";
-import { TerminalStyle } from "../../types/terminal-types";
-
-interface TerminalContentProps {
-  style: TerminalStyle;
-  text: string;
-  lineText: string;
-  animationComplete: boolean;
-}
+import { TerminalContentProps } from "@/types/loading-component-types";
 
 /**
  * Terminal content area with text and cursor

--- a/src/components/Loading/TerminalHeader.tsx
+++ b/src/components/Loading/TerminalHeader.tsx
@@ -1,10 +1,5 @@
 import React from "react";
-import { TerminalStyle } from "../../types/terminal-types";
-
-interface TerminalHeaderProps {
-  style: TerminalStyle;
-  title?: string;
-}
+import { TerminalHeaderProps } from "@/types/loading-component-types";
 
 /**
  * Terminal window header with traffic light buttons

--- a/src/components/Navbar/ActionButtons.tsx
+++ b/src/components/Navbar/ActionButtons.tsx
@@ -3,11 +3,7 @@ import { Github } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/Theme-Provider/theme-toggle";
 import SearchDialog from "@/components/Search-Dialog/SearchDialog";
-
-interface ActionButtonsProps {
-  theme: string | undefined;
-  blackText?: React.CSSProperties;
-}
+import { ActionButtonsProps } from "@/types/navbar-component-types";
 
 /**
  * Action buttons component (search, theme, GitHub) for desktop view

--- a/src/components/Navbar/MobileMenu.tsx
+++ b/src/components/Navbar/MobileMenu.tsx
@@ -1,13 +1,7 @@
 import React from "react";
 import { Menu, X } from "lucide-react";
 import { ThemeToggle } from "@/components/Theme-Provider/theme-toggle";
-
-interface MobileMenuProps {
-  isOpen: boolean;
-  toggleMenu: () => void;
-  theme: string | undefined;
-  blackText?: React.CSSProperties;
-}
+import { MobileMenuProps } from "@/types/navbar-component-types";
 
 /**
  * Mobile menu toggle button component

--- a/src/components/Navbar/NavbarBrand.tsx
+++ b/src/components/Navbar/NavbarBrand.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { useTheme } from "next-themes";
-
-interface NavbarBrandProps {
-  scrollToSection: (sectionId: string) => void;
-  textColorClass: string;
-}
+import { NavbarBrandProps } from "@/types/navbar-component-types";
 
 /**
  * Brand logo component for the navbar

--- a/src/components/Navbar/NavigationItems.tsx
+++ b/src/components/Navbar/NavigationItems.tsx
@@ -1,15 +1,6 @@
 import React from "react";
 import { Code, Paintbrush, Cpu } from "lucide-react";
-
-interface NavigationItemsProps {
-  scrollToSection: (sectionId: string) => void;
-  isActive: (sectionId: string) => boolean;
-  textColorClass: string;
-  mutedTextColorClass: string;
-  activeBgClass: string;
-  hoverBgClass: string;
-  blackText?: React.CSSProperties;
-}
+import { NavigationItemsProps } from "@/types/navbar-component-types";
 
 /**
  * Navigation items component for desktop view

--- a/src/components/Search-Dialog/CategoryButtons.tsx
+++ b/src/components/Search-Dialog/CategoryButtons.tsx
@@ -1,10 +1,6 @@
 import React from "react";
+import { CategoryButtonsProps } from "@/types/search-dialog-component-types";
 import { Category } from "../../types/search-types";
-
-interface CategoryButtonsProps {
-  selectedCategory: Category;
-  setSelectedCategory: (category: Category) => void;
-}
 
 export function CategoryButtons({
   selectedCategory,

--- a/src/components/Search-Dialog/FilterDropdown.tsx
+++ b/src/components/Search-Dialog/FilterDropdown.tsx
@@ -1,36 +1,29 @@
 import React, { RefObject } from "react";
 import { Menu, Check } from "lucide-react";
 import { Category } from "../../types/search-types";
+import { FilterDropdownProps } from "@/types/search-dialog-component-types";
 
-interface FilterDropdownProps {
-  selectedCategory: Category;
-  setSelectedCategory: (category: Category) => void;
-  filterMenuOpen: boolean;
-  setFilterMenuOpen: (isOpen: boolean) => void;
-  filterMenuRef: RefObject<HTMLDivElement>;
-}
-
-export function FilterDropdown({ 
-  selectedCategory, 
-  setSelectedCategory, 
-  filterMenuOpen, 
+export function FilterDropdown({
+  selectedCategory,
+  setSelectedCategory,
+  filterMenuOpen,
   setFilterMenuOpen,
-  filterMenuRef
+  filterMenuRef,
 }: FilterDropdownProps) {
   const categories: Category[] = ["Suggested", "Development", "Design", "AI"];
-  
+
   return (
     <div className="relative sm:hidden" ref={filterMenuRef}>
       <button
         onClick={() => setFilterMenuOpen(!filterMenuOpen)}
-        className="flex items-center gap-2 px-3 py-1 rounded-full bg-muted text-muted-foreground hover:bg-purple-200"
+        className="flex items-center gap-2 rounded-full bg-muted px-3 py-1 text-muted-foreground hover:bg-purple-200"
       >
         <Menu className="h-3.5 w-3.5" />
         <span className="text-xs font-medium">{selectedCategory}</span>
       </button>
-      
+
       {filterMenuOpen && (
-        <div className="absolute top-full left-0 mt-1 w-36 bg-card rounded-lg border shadow-md z-50 py-1">
+        <div className="absolute left-0 top-full z-50 mt-1 w-36 rounded-lg border bg-card py-1 shadow-md">
           {categories.map((category) => (
             <button
               key={category}
@@ -38,12 +31,18 @@ export function FilterDropdown({
                 setSelectedCategory(category);
                 setFilterMenuOpen(false);
               }}
-              className="flex items-center w-full px-3 py-2 hover:bg-muted text-left text-sm"
+              className="flex w-full items-center px-3 py-2 text-left text-sm hover:bg-muted"
             >
               {selectedCategory === category && (
-                <Check className="h-3.5 w-3.5 mr-2 text-purple-500" />
+                <Check className="mr-2 h-3.5 w-3.5 text-purple-500" />
               )}
-              <span className={selectedCategory === category ? "text-purple-500 font-medium" : ""}>
+              <span
+                className={
+                  selectedCategory === category
+                    ? "font-medium text-purple-500"
+                    : ""
+                }
+              >
                 {category}
               </span>
             </button>
@@ -52,4 +51,4 @@ export function FilterDropdown({
       )}
     </div>
   );
-} 
+}

--- a/src/components/Search-Dialog/SortButton.tsx
+++ b/src/components/Search-Dialog/SortButton.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { ArrowUpDown } from "lucide-react";
-
-interface SortButtonProps {
-  sortAlphabetically: boolean;
-  setSortAlphabetically: (value: boolean) => void;
-}
+import { SortButtonProps } from "@/types/search-dialog-component-types";
 
 export function SortButton({
   sortAlphabetically,

--- a/src/components/Search-Dialog/ToolItem.tsx
+++ b/src/components/Search-Dialog/ToolItem.tsx
@@ -1,10 +1,5 @@
 import React from "react";
-import { Tool } from "../../types/search-types";
-
-interface ToolItemProps {
-  tool: Tool;
-  onClick: () => void;
-}
+import { ToolItemProps } from "@/types/search-dialog-component-types";
 
 export function ToolItem({ tool, onClick }: ToolItemProps) {
   return (

--- a/src/components/Smooth-Scroll/ScrollToElement.tsx
+++ b/src/components/Smooth-Scroll/ScrollToElement.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
-
-type ScrollToElementProps = {
-  children: ReactNode;
-  targetId: string;
-  offset?: number;
-  className?: string;
-};
+import { ScrollToElementProps } from "@/types/smooth-scroll-component-types";
 
 export function ScrollToElement({
   children,

--- a/src/components/Tool-Details/ToolBenefits.tsx
+++ b/src/components/Tool-Details/ToolBenefits.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-
-interface ToolBenefitsProps {
-  benefits: string[];
-  theme: string | undefined;
-}
+import { ToolBenefitsProps } from "@/types/tool-details-component-types";
 
 /**
  * Benefits component for the tool details dialog

--- a/src/components/Tool-Details/ToolDescription.tsx
+++ b/src/components/Tool-Details/ToolDescription.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { DialogDescription } from "@/components/ui/dialog";
-
-interface ToolDescriptionProps {
-  description: string;
-  theme: string | undefined;
-}
+import { ToolDescriptionProps } from "@/types/tool-details-component-types";
 
 /**
  * Description component for the tool details dialog

--- a/src/components/Tool-Details/ToolDetails.tsx
+++ b/src/components/Tool-Details/ToolDetails.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import React from "react";
-import { Tool } from "@/types/tool-types";
 import { useTheme } from "next-themes";
 import { X } from "lucide-react";
+import { ToolDetailsProps } from "@/types/tool-details-component-types";
 
 // Import custom dialog components without the default close button
 import {
@@ -17,12 +17,6 @@ import { ToolHeader } from "./ToolHeader";
 import { ToolDescription } from "./ToolDescription";
 import { ToolBenefits } from "./ToolBenefits";
 import { ToolFooter } from "./ToolFooter";
-
-interface ToolDetailsProps {
-  isOpen: boolean;
-  onClose: () => void;
-  tool: Tool | null;
-}
 
 const ToolDetails = ({ isOpen, onClose, tool }: ToolDetailsProps) => {
   const { theme } = useTheme();

--- a/src/components/Tool-Details/ToolFooter.tsx
+++ b/src/components/Tool-Details/ToolFooter.tsx
@@ -2,13 +2,7 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { ArrowRight, ExternalLink } from "lucide-react";
-
-interface ToolFooterProps {
-  category?: string;
-  tryNowLink?: string;
-  link?: string;
-  theme: string | undefined;
-}
+import { ToolFooterProps } from "@/types/tool-details-component-types";
 
 /**
  * Footer component for the tool details dialog

--- a/src/components/Tool-Details/ToolHeader.tsx
+++ b/src/components/Tool-Details/ToolHeader.tsx
@@ -1,16 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import { DialogTitle } from "@/components/ui/dialog";
-import { LucideIcon } from "lucide-react";
-
-interface ToolHeaderProps {
-  title: string;
-  imageIcon?: string;
-  icon?: LucideIcon;
-  category?: string;
-  highlight?: string;
-  theme: string | undefined;
-}
+import { ToolHeaderProps } from "@/types/tool-details-component-types";
 
 /**
  * Header component for the tool details dialog

--- a/src/types/card-component-types.ts
+++ b/src/types/card-component-types.ts
@@ -1,0 +1,42 @@
+import { LucideIcon } from "lucide-react";
+import React from "react";
+
+/**
+ * Props for the BenefitsList component
+ * Displays a list of benefit tags for a tool
+ */
+export interface BenefitsListProps {
+  benefits: string[];
+  theme: string | undefined;
+}
+
+/**
+ * Props for the CardFooter component
+ * Footer component for Tool Cards with highlight badge and action button
+ */
+export interface CardFooterProps {
+  highlight: string;
+  theme: string | undefined;
+  onViewDetails: () => void;
+}
+
+/**
+ * Props for the CategoryBadge component
+ * Displays the category badge for a tool
+ */
+export interface CategoryBadgeProps {
+  category: string;
+  theme: string | undefined;
+}
+
+/**
+ * Props for the ToolIcon component
+ * Displays either an image icon or Lucide icon for a tool
+ */
+export interface ToolIconProps {
+  Icon?: LucideIcon;
+  imageIcon?: string;
+  title: string;
+  theme: string | undefined;
+  iconRef: React.RefObject<HTMLDivElement>;
+}

--- a/src/types/category-component-types.ts
+++ b/src/types/category-component-types.ts
@@ -1,0 +1,30 @@
+import { Tool } from "./tool-types";
+
+/**
+ * Props for the CategoryHeader component
+ * Section header for tool categories with title and description
+ */
+export interface CategoryHeaderProps {
+  title: string;
+  description: string;
+}
+
+/**
+ * Props for the Pagination component
+ * Handles pagination controls with responsive design
+ */
+export interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+}
+
+/**
+ * Props for the ToolGrid component
+ * Grid layout component for displaying tool cards
+ */
+export interface ToolGridProps {
+  tools: Tool[];
+  initialToolsLoaded: boolean;
+}

--- a/src/types/footer-component-types.ts
+++ b/src/types/footer-component-types.ts
@@ -1,0 +1,74 @@
+/**
+ * Props for the BackToTopButton component
+ * A button that appears when scrolling down to let users quickly go back to the top
+ */
+export interface BackToTopButtonProps {
+  showButton: boolean;
+  isDark: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Props for the FooterBackground component
+ * Background visual effects for the footer
+ */
+export interface FooterBackgroundProps {
+  isDark: boolean;
+}
+
+/**
+ * Props for the FooterBottom component
+ * Bottom section of the footer with copyright and credits
+ */
+export interface FooterBottomProps {
+  isDark: boolean;
+  currentYear: number;
+}
+
+/**
+ * Props for the FooterBrand component
+ * The brand section of the footer with logo and description
+ */
+export interface FooterBrandProps {
+  isDark: boolean;
+}
+
+/**
+ * Props for the FooterContact component
+ * Contact section in the footer with GitHub links
+ */
+export interface FooterContactProps {
+  isDark: boolean;
+}
+
+/**
+ * Contact link data structure
+ */
+export interface ContactLink {
+  href: string;
+  username: string;
+}
+
+/**
+ * Props for the FooterDivider component
+ * Animated divider for separating footer sections
+ */
+export interface FooterDividerProps {
+  isDark: boolean;
+}
+
+/**
+ * Props for the FooterNavigation component
+ * Navigation links section in the footer
+ */
+export interface FooterNavigationProps {
+  isDark: boolean;
+}
+
+/**
+ * Navigation link data structure
+ */
+export interface NavigationLink {
+  href: string;
+  label: string;
+}

--- a/src/types/jumbotron-component-types.ts
+++ b/src/types/jumbotron-component-types.ts
@@ -1,0 +1,42 @@
+import { RefObject } from "react";
+import { FeatureItem, MousePosition } from "./jumbotron-types";
+
+/**
+ * Props for the Decorations component
+ * Decorative elements for the jumbotron section
+ */
+export interface DecorationsProps {
+  isDark: boolean;
+  decorationsRef: RefObject<HTMLDivElement>;
+}
+
+/**
+ * Props for the FeatureCard component
+ * A card component for displaying feature information
+ */
+export interface FeatureCardProps {
+  feature: FeatureItem;
+  isDark: boolean;
+}
+
+/**
+ * Props for the JumbotronBackground component
+ * Component for displaying all the background visual elements of the jumbotron
+ */
+export interface JumbotronBackgroundProps {
+  isDark: boolean;
+  isMounted: boolean;
+  isMobileOrTablet: boolean;
+  mousePosition: MousePosition;
+}
+
+/**
+ * Props for the TerminalDisplay component
+ * Terminal display component with animated typing effect
+ */
+export interface TerminalDisplayProps {
+  isDark: boolean;
+  typedText: string;
+  isTyping: boolean;
+  dashboardCodeRef: RefObject<HTMLDivElement>;
+}

--- a/src/types/loading-component-types.ts
+++ b/src/types/loading-component-types.ts
@@ -1,0 +1,33 @@
+import { TerminalStyle } from "./terminal-types";
+
+/**
+ * Props for the Terminal component
+ * Terminal window component combining header and content
+ */
+export interface TerminalProps {
+  style: TerminalStyle;
+  text: string;
+  lineText: string;
+  animationComplete: boolean;
+  title?: string;
+}
+
+/**
+ * Props for the TerminalContent component
+ * Terminal content area with text and cursor
+ */
+export interface TerminalContentProps {
+  style: TerminalStyle;
+  text: string;
+  lineText: string;
+  animationComplete: boolean;
+}
+
+/**
+ * Props for the TerminalHeader component
+ * Terminal window header with traffic light buttons
+ */
+export interface TerminalHeaderProps {
+  style: TerminalStyle;
+  title?: string;
+}

--- a/src/types/navbar-component-types.ts
+++ b/src/types/navbar-component-types.ts
@@ -1,0 +1,44 @@
+import React from "react";
+
+/**
+ * Props for the ActionButtons component
+ * Action buttons component (search, theme, GitHub) for desktop view
+ */
+export interface ActionButtonsProps {
+  theme: string | undefined;
+  blackText?: React.CSSProperties;
+}
+
+/**
+ * Props for the MobileMenu component
+ * Mobile menu toggle button component
+ */
+export interface MobileMenuProps {
+  isOpen: boolean;
+  toggleMenu: () => void;
+  theme: string | undefined;
+  blackText?: React.CSSProperties;
+}
+
+/**
+ * Props for the NavbarBrand component
+ * Brand logo component for the navbar
+ */
+export interface NavbarBrandProps {
+  scrollToSection: (sectionId: string) => void;
+  textColorClass: string;
+}
+
+/**
+ * Props for the NavigationItems component
+ * Navigation items component for desktop view
+ */
+export interface NavigationItemsProps {
+  scrollToSection: (sectionId: string) => void;
+  isActive: (sectionId: string) => boolean;
+  textColorClass: string;
+  mutedTextColorClass: string;
+  activeBgClass: string;
+  hoverBgClass: string;
+  blackText?: React.CSSProperties;
+}

--- a/src/types/search-dialog-component-types.ts
+++ b/src/types/search-dialog-component-types.ts
@@ -1,0 +1,41 @@
+import { RefObject } from "react";
+import { Category, Tool } from "./search-types";
+
+/**
+ * Props for the CategoryButtons component
+ * Category filter buttons for desktop view
+ */
+export interface CategoryButtonsProps {
+  selectedCategory: Category;
+  setSelectedCategory: (category: Category) => void;
+}
+
+/**
+ * Props for the FilterDropdown component
+ * Mobile dropdown menu for category filtering
+ */
+export interface FilterDropdownProps {
+  selectedCategory: Category;
+  setSelectedCategory: (category: Category) => void;
+  filterMenuOpen: boolean;
+  setFilterMenuOpen: (isOpen: boolean) => void;
+  filterMenuRef: RefObject<HTMLDivElement>;
+}
+
+/**
+ * Props for the SortButton component
+ * Button to toggle alphabetical sorting
+ */
+export interface SortButtonProps {
+  sortAlphabetically: boolean;
+  setSortAlphabetically: (value: boolean) => void;
+}
+
+/**
+ * Props for the ToolItem component
+ * Individual tool item in the search results
+ */
+export interface ToolItemProps {
+  tool: Tool;
+  onClick: () => void;
+}

--- a/src/types/smooth-scroll-component-types.ts
+++ b/src/types/smooth-scroll-component-types.ts
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+
+/**
+ * Props for the ScrollToElement component
+ * A component that scrolls to a target element when clicked
+ */
+export interface ScrollToElementProps {
+  children: ReactNode;
+  targetId: string;
+  offset?: number;
+  className?: string;
+}

--- a/src/types/tool-details-component-types.ts
+++ b/src/types/tool-details-component-types.ts
@@ -1,0 +1,54 @@
+import { LucideIcon } from "lucide-react";
+import { Tool } from "./tool-types";
+
+/**
+ * Props for the ToolBenefits component
+ * Benefits component for the tool details dialog
+ */
+export interface ToolBenefitsProps {
+  benefits: string[];
+  theme: string | undefined;
+}
+
+/**
+ * Props for the ToolDescription component
+ * Description component for the tool details dialog
+ */
+export interface ToolDescriptionProps {
+  description: string;
+  theme: string | undefined;
+}
+
+/**
+ * Props for the ToolDetails component
+ * Main tool details dialog component
+ */
+export interface ToolDetailsProps {
+  isOpen: boolean;
+  onClose: () => void;
+  tool: Tool | null;
+}
+
+/**
+ * Props for the ToolFooter component
+ * Footer component for the tool details dialog
+ */
+export interface ToolFooterProps {
+  category?: string;
+  tryNowLink?: string;
+  link?: string;
+  theme: string | undefined;
+}
+
+/**
+ * Props for the ToolHeader component
+ * Header component for the tool details dialog
+ */
+export interface ToolHeaderProps {
+  title: string;
+  imageIcon?: string;
+  icon?: LucideIcon;
+  category?: string;
+  highlight?: string;
+  theme: string | undefined;
+}


### PR DESCRIPTION
## Summary
This PR refactors the codebase by extracting and centralizing component prop type definitions into dedicated files under the /types directory.

## Changes

- Moved inline TypeScript interfaces from components into structured type files:
   - card-component-types.ts
   - category-component-types.ts
   - footer-component-types.ts
   - jumbotron-component-types.ts
   - loading-component-types.ts
   - navbar-component-types.ts
   - search-dialog-component-types.ts
   - smooth-scroll-component-types.ts
   - tool-details-component-types.ts
- Updated all components to import their respective prop types from the new type modules
- Removed redundant and duplicated interface definitions across components
- Minor formatting and consistency improvements

## Why

- Improves code organization and maintainability
- Promotes reusability of type definitions
- Reduces duplication and risk of inconsistencies
- Makes components cleaner and easier to read

## Impact

- No functional changes
- Purely a structural/refactor update